### PR TITLE
Add hosted chef node status action

### DIFF
--- a/packs/chef/actions/hosted_chef_node_status.py
+++ b/packs/chef/actions/hosted_chef_node_status.py
@@ -1,0 +1,32 @@
+import time
+from lib.hosted_chef_action import HostedChefBaseAction
+
+__all__ = [
+    'NodesStatusAction'
+]
+
+
+class NodesStatusAction(HostedChefBaseAction):
+    def run(self):
+        nodes = self.nodes.keys()
+        now = int(time.time())
+        node_status = []
+        for n in nodes:
+            last_checked_in = n.attributes['ohai_time']
+            os = n.attributes['platform']
+            pretty_time = time.strftime("%Y-%m-%d %H:%M:%S", last_checked_in)
+
+            if now - last_checked_in > 1800:
+                status = 'unhealthy'
+            else:
+                status = 'healthy'
+
+            node_status.append({
+                'name': n,
+                'os': os,
+                'environment': environment,
+                'status': status,
+                'last checkin': pretty_time,
+            })
+
+        return node_status

--- a/packs/chef/actions/hosted_chef_node_status.yaml
+++ b/packs/chef/actions/hosted_chef_node_status.yaml
@@ -1,0 +1,7 @@
+---
+name: hosted_chef_node_status
+runner_type: run-python
+description: Get status of nodes from Hosted Chef
+enabled: true
+entry_point: hosted_chef_node_status.py
+parameters: {}

--- a/packs/chef/requirements.txt
+++ b/packs/chef/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/ryandub/pychef.git@cryptofix
+arrow==0.5.0


### PR DESCRIPTION
This will check the status of nodes and report back:

node name
chef environment
os of the node (based on ohai's platform attribute)
status (healthy or unhealthy: unhealthy means the node has not run chef in 30 minutes)
the last time the node ran chef (based on ohai_time attribute)
